### PR TITLE
Added "DeterministicPolynomial" func, set RandomPolynomial to use it

### DIFF
--- a/chunker_test.go
+++ b/chunker_test.go
@@ -175,6 +175,9 @@ func TestChunkerWithRandomPolynomial(t *testing.T) {
 
 	// make sure that first chunk is different
 	c, err := ch.Next(nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 
 	if c.Cut == chunks1[0].CutFP {
 		t.Fatal("Cut point is the same")

--- a/polynomials.go
+++ b/polynomials.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 )
 
@@ -154,17 +155,25 @@ func (x Pol) Mod(d Pol) Pol {
 // randPolMaxTries.
 const randPolMaxTries = 1e6
 
-// RandomPolynomial returns a new random irreducible polynomial of degree 53
-// (largest prime number below 64-8). There are (2^53-2/53) irreducible
-// polynomials of degree 53 in F_2[X], c.f. Michael O. Rabin (1981):
-// "Fingerprinting by Random Polynomials", page 4. If no polynomial could be
-// found in one million tries, an error is returned.
+// RandomPolynomial returns a new random irreducible polynomial
+// of degree 53 using the default System CSPRNG as source.
+// It is equivalent to calling DerivePolynomial(rand.Reader).
 func RandomPolynomial() (Pol, error) {
+	return DerivePolynomial(rand.Reader)
+}
+
+// DerivePolynomial returns an irreducible polynomial of degree 53
+// (largest prime number below 64-8) by reading bytes from source.
+// There are (2^53-2/53) irreducible polynomials of degree 53 in
+// F_2[X], c.f. Michael O. Rabin (1981): "Fingerprinting by Random
+// Polynomials", page 4. If no polynomial could be found in one
+// million tries, an error is returned.
+func DerivePolynomial(source io.Reader) (Pol, error) {
 	for i := 0; i < randPolMaxTries; i++ {
 		var f Pol
 
-		// choose polynomial at random
-		err := binary.Read(rand.Reader, binary.LittleEndian, &f)
+		// choose polynomial at (pseudo)random
+		err := binary.Read(source, binary.LittleEndian, &f)
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
Hi folks,

I'm working on something that will use chunker, and I'd like to be able to deterministically generate Polynomials from secure pseudorandom input (I'll be using SHAKE256).

The changes here are self-explanatory; instead of hardcoding rand.Source I'm accepting a reader, and the `RandomPolynomial` function now simply passes rand.Source to the DeterministicPolynomial function.

Also, my linter was complaining about the dangling err in the tests, so I fatal'd it; hope you don't mind. :)

Current test suite passes, but I haven't made tests for the new DeterministicPolynomial function yet.