### PR TITLE
Respect the capacity of the passed-in data and do not exceed it

### DIFF
--- a/chunker.go
+++ b/chunker.go
@@ -3,6 +3,7 @@ package chunker
 import (
 	"errors"
 	"io"
+	"math"
 	"sync"
 )
 
@@ -209,7 +210,7 @@ func (c *Chunker) Next(data []byte) (Chunk, error) {
 	tabmod := c.tables.mod
 	polShift := c.polShift
 	minSize := c.MinSize
-	maxSize := c.MaxSize
+	maxSize := uint(math.Min(float64(c.MaxSize), float64(cap(data))))
 	buf := c.buf
 	for {
 		if c.bpos >= c.bmax {


### PR DESCRIPTION
I must admit I don't quite understand why data gets passed into Next() at all, since the resulting chunk's data gets returned along with the Chunk struct and its value gets ignored either way.

I think it might be a good idea to respect the passed in data's capacity and consider it the expected maximum chunk size. One could also remove the parameter entirely, create the buffer internally in Next() and allow for setting a custom config to let the user specify min- and max-values. Happy to do that if that's the eventual design goal of this library.