### PR TITLE
Ditching modulo in favor of comparison and reset

### DIFF
--- a/chunker.go
+++ b/chunker.go
@@ -294,7 +294,10 @@ func (c *Chunker) Next(data []byte) (Chunk, error) {
 			out := win[wpos]
 			win[wpos] = b
 			digest ^= uint64(tabout[out])
-			wpos = (wpos + 1) % windowSize
+			wpos++
+			if wpos >= windowSize {
+				wpos = 0
+			}
 
 			// updateDigest
 			index := byte(digest >> polShift)


### PR DESCRIPTION
Hi,

In go, a comparison is faster than a modulo, so updating the wpos index is done much faster by adding 1 and then resetting it to 0 if the windowSize is exceeded, rather than adding 1 and then taking the result modulo windowSize.

This change is functionally strictly equivalent, and on my computer it yields 10 to 50% additional speed in the chunker.

Cheers!