### PR TITLE
polynomials: Remove unsed x calculation in Deg()

### DIFF
--- a/polynomials.go
+++ b/polynomials.go
@@ -94,7 +94,6 @@ func (x Pol) Deg() int {
 	}
 
 	if uint64(x)&0x2 > 0 {
-		x >>= 1
 		r |= 1
 	}
 


### PR DESCRIPTION
Only `r` is used, to save the climate the unnecessary calculation of`x` is removed.