### PR TITLE
Improve performance of Rabin fingerprint calculation

### DIFF
--- a/chunker.go
+++ b/chunker.go
@@ -47,7 +47,7 @@ type Chunk struct {
 
 type chunkerState struct {
 	window [windowSize]byte
-	wpos   int
+	wpos   uint
 
 	buf  []byte
 	bpos uint
@@ -295,9 +295,7 @@ func (c *Chunker) Next(data []byte) (Chunk, error) {
 			win[wpos] = b
 			digest ^= uint64(tabout[out])
 			wpos++
-			if wpos >= windowSize {
-				wpos = 0
-			}
+			wpos = wpos % windowSize
 
 			// updateDigest
 			index := byte(digest >> polShift)

--- a/chunker.go
+++ b/chunker.go
@@ -225,6 +225,12 @@ func (c *Chunker) Next(data []byte) (Chunk, error) {
 	tabout := c.tables.out
 	tabmod := c.tables.mod
 	polShift := c.polShift
+	// go guarantees the expected behavior for bit shifts even for shift counts
+	// larger than the value width. Bounding the value of polShift allows the compiler
+	// to optimize the code for 'digest >> polShift'
+	if polShift > 53-8 {
+		return Chunk{}, errors.New("the polynomial must have a degree less than or equal 53")
+	}
 	minSize := c.MinSize
 	maxSize := c.MaxSize
 	buf := c.buf

--- a/chunker.go
+++ b/chunker.go
@@ -291,11 +291,12 @@ func (c *Chunker) Next(data []byte) (Chunk, error) {
 		wpos := c.wpos
 		for _, b := range buf[c.bpos:c.bmax] {
 			// slide(b)
+			// limit wpos before to elide array bound checks
+			wpos = wpos % windowSize
 			out := win[wpos]
 			win[wpos] = b
 			digest ^= uint64(tabout[out])
 			wpos++
-			wpos = wpos % windowSize
 
 			// updateDigest
 			index := byte(digest >> polShift)
@@ -332,7 +333,7 @@ func (c *Chunker) Next(data []byte) (Chunk, error) {
 		}
 		c.digest = digest
 		c.window = win
-		c.wpos = wpos
+		c.wpos = wpos % windowSize
 
 		steps := c.bmax - c.bpos
 		if steps > 0 {


### PR DESCRIPTION
These patches improve the chunking throughput by about 10-23% depending on the CPU used. The speedup is more noticeable on older CPUs.

The test were run on Linux using go 1.11.6 with `go test -bench 'BenchmarkChunker$' -cpu 1 -benchtime 20s`. I've also repeated the complete performance measurements three times. As the results were quite stable (except for 1 extreme slow outlier), I've just included the results from the second measurement run.

Would it be possible to create a new release for use in restic? The version there is already missing commit 7c2a180e7ccb779348b1102f054cecbab2cd1c20 which improves the performance to the baseline for the first commit in the merge request. For tag v0.2.0, which is the version used in restic, I've measured the following throughput:

```
Old CPU: Intel(R) Xeon(R) CPU E5506 @ 2.13GHz
BenchmarkChunker                     200         169683667 ns/op         197.75 MB/s

Modern CPU: Intel(R) Xeon(R) CPU E3-1275 v5 @ 3.60GHz
BenchmarkChunker                     500          64142688 ns/op         523.12 MB/s
```

This totals up to 15-36% more throughput than v0.2.0 .