### PR TITLE
27-fold speedup for Pol.Deg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/restic/chunker
+
+go 1.9

--- a/polynomials.go
+++ b/polynomials.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/bits"
 	"strconv"
 )
 
@@ -60,44 +61,7 @@ func (x Pol) Mul(y Pol) Pol {
 
 // Deg returns the degree of the polynomial x. If x is zero, -1 is returned.
 func (x Pol) Deg() int {
-	// the degree of 0 is -1
-	if x == 0 {
-		return -1
-	}
-
-	// see https://graphics.stanford.edu/~seander/bithacks.html#IntegerLog
-
-	r := 0
-	if uint64(x)&0xffffffff00000000 > 0 {
-		x >>= 32
-		r |= 32
-	}
-
-	if uint64(x)&0xffff0000 > 0 {
-		x >>= 16
-		r |= 16
-	}
-
-	if uint64(x)&0xff00 > 0 {
-		x >>= 8
-		r |= 8
-	}
-
-	if uint64(x)&0xf0 > 0 {
-		x >>= 4
-		r |= 4
-	}
-
-	if uint64(x)&0xc > 0 {
-		x >>= 2
-		r |= 2
-	}
-
-	if uint64(x)&0x2 > 0 {
-		r |= 1
-	}
-
-	return r
+	return bits.Len64(uint64(x)) - 1
 }
 
 // String returns the coefficients in hex.

--- a/polynomials_test.go
+++ b/polynomials_test.go
@@ -242,9 +242,12 @@ func BenchmarkPolDeg(t *testing.B) {
 			d, 41)
 	}
 
+	var sum int
 	for i := 0; i < t.N; i++ {
-		f.Deg()
+		sum += f.Deg()
 	}
+	// Make sure Deg call isn't optimized away.
+	t.Log("sum of Deg:", sum)
 }
 
 func TestRandomPolynomial(t *testing.T) {


### PR DESCRIPTION
I'm not sure how long you want to continue to support Go < 1.9, but if you don't, Pol.Deg can be made almost 27× faster.

```
name                 old time/op   new time/op   delta
ChunkerWithSHA256-8    205ms ± 0%    205ms ± 0%   -0.14%  (p=0.019 n=10+10)
Chunker-8             57.7ms ± 0%   57.6ms ± 0%   -0.16%  (p=0.043 n=9+10)
NewChunker-8          97.2µs ± 2%   93.8µs ± 2%   -3.55%  (p=0.000 n=9+10)
PolDivMod-8           17.8ns ± 0%    3.6ns ± 0%  -79.69%  (p=0.000 n=8+9)
PolDiv-8              18.0ns ± 0%    3.6ns ± 0%  -80.19%  (p=0.000 n=10+10)
PolMod-8              18.0ns ± 0%    3.6ns ± 1%  -79.85%  (p=0.000 n=6+9)
PolDeg-8              7.36ns ± 0%   0.27ns ± 2%  -96.28%  (p=0.000 n=8+10)
RandomPolynomial-8     102ms ±13%     28ms ±11%  -72.81%  (p=0.000 n=10+10)
PolIrreducible-8      62.4ms ± 0%   15.3ms ± 1%  -75.47%  (p=0.000 n=10+9)

name                 old speed     new speed     delta
ChunkerWithSHA256-8  164MB/s ± 0%  164MB/s ± 0%   +0.14%  (p=0.020 n=10+10)
Chunker-8            582MB/s ± 0%  583MB/s ± 0%   +0.16%  (p=0.037 n=9+10)
```