### PR TITLE
Speed up RandomPolynomial by a factor 13

### DIFF
--- a/polynomials.go
+++ b/polynomials.go
@@ -18,25 +18,15 @@ func (x Pol) Add(y Pol) Pol {
 	return r
 }
 
-// mulOverflows returns true if the multiplication would overflow uint64.
-// Code by Rob Pike, see
-// https://groups.google.com/d/msg/golang-nuts/h5oSN5t3Au4/KaNQREhZh0QJ
-func mulOverflows(a, b Pol) bool {
-	if a <= 1 || b <= 1 {
-		return false
-	}
-	c := a.mul(b)
-	d := c.Div(b)
-	if d != a {
-		return true
-	}
-
-	return false
-}
-
-func (x Pol) mul(y Pol) Pol {
-	if x == 0 || y == 0 {
+// Mul returns x*y. When an overflow occurs, Mul panics.
+func (x Pol) Mul(y Pol) Pol {
+	switch {
+	case x == 0 || y == 0:
 		return 0
+	case x == 1:
+		return y
+	case y == 1:
+		return x
 	}
 
 	var res Pol
@@ -46,16 +36,11 @@ func (x Pol) mul(y Pol) Pol {
 		}
 	}
 
-	return res
-}
-
-// Mul returns x*y. When an overflow occurs, Mul panics.
-func (x Pol) Mul(y Pol) Pol {
-	if mulOverflows(x, y) {
+	if res.Div(y) != x {
 		panic("multiplication would overflow uint64")
 	}
 
-	return x.mul(y)
+	return res
 }
 
 // Deg returns the degree of the polynomial x. If x is zero, -1 is returned.

--- a/polynomials.go
+++ b/polynomials.go
@@ -27,6 +27,8 @@ func (x Pol) Mul(y Pol) Pol {
 		return y
 	case y == 1:
 		return x
+	case y == 2:
+		return x.mul2()
 	}
 
 	var res Pol
@@ -41,6 +43,14 @@ func (x Pol) Mul(y Pol) Pol {
 	}
 
 	return res
+}
+
+// 2*x.
+func (x Pol) mul2() Pol {
+	if x&(1<<63) != 0 {
+		panic("multiplication would overflow uint64")
+	}
+	return x << 1
 }
 
 // Deg returns the degree of the polynomial x. If x is zero, -1 is returned.


### PR DESCRIPTION
The first commit avoids having to do the multiplication twice and speeds up Pol.Irreducible:

```
name              old time/op  new time/op  delta
PolIrreducible-8  62.4ms ± 0%  57.4ms ± 0%  -8.11%  (p=0.000 n=10+10)
```

The second introduces a fast path for Pol.Mul(x, 2), for a combined speedup of:

    name                old time/op  new time/op  delta
    RandomPolynomial-8   102ms ±13%     8ms ± 8%  -92.55%  (p=0.000 n=10+10)
    PolIrreducible-8    62.4ms ± 0%   4.3ms ± 0%  -93.04%  (p=0.000 n=10+7)
