### PR TITLE
Pass tables by pointer in Chunker.slide/updateDigest

### DIFF
--- a/chunker.go
+++ b/chunker.go
@@ -351,7 +351,7 @@ func (c *Chunker) Next(data []byte) (Chunk, error) {
 	}
 }
 
-func updateDigest(digest uint64, polShift uint, tab tables, b byte) (newDigest uint64) {
+func updateDigest(digest uint64, polShift uint, tab *tables, b byte) (newDigest uint64) {
 	index := digest >> polShift
 	digest <<= 8
 	digest |= uint64(b)
@@ -366,7 +366,7 @@ func (c *Chunker) slide(digest uint64, b byte) (newDigest uint64) {
 	digest ^= uint64(c.tables.out[out])
 	c.wpos = (c.wpos + 1) % windowSize
 
-	digest = updateDigest(digest, c.polShift, c.tables, b)
+	digest = updateDigest(digest, c.polShift, &c.tables, b)
 	return digest
 }
 


### PR DESCRIPTION
Passing them by value causes 4kB to be copied on the stack.

This fixes a performance regression introduced in 61d1f1201ee7a05492f86f79d309f6b8477a12a0.

```
name                 old time/op   new time/op   delta
ChunkerWithSHA256-8    205ms ± 0%    205ms ± 0%  -0.20%  (p=0.001 n=10+10)
Chunker-8             57.7ms ± 0%   57.6ms ± 0%  -0.16%  (p=0.035 n=9+10)
NewChunker-8          97.2µs ± 2%   93.0µs ± 1%  -4.28%  (p=0.000 n=9+10)

name                 old speed     new speed     delta
ChunkerWithSHA256-8  164MB/s ± 0%  164MB/s ± 0%  +0.20%  (p=0.001 n=10+10)
Chunker-8            582MB/s ± 0%  583MB/s ± 0%  +0.16%  (p=0.035 n=9+10)
```