### PR TITLE
Only check for minimum chunk size after finding a split point

### DIFF
--- a/chunker.go
+++ b/chunker.go
@@ -313,11 +313,12 @@ func (c *Chunker) Next(data []byte) (Chunk, error) {
 			// end manual inline
 
 			add++
-			if add < minSize {
-				continue
-			}
 
 			if (digest&c.splitmask) == 0 || add >= maxSize {
+				if add < minSize {
+					continue
+				}
+
 				i := add - c.count - 1
 				data = append(data, c.buf[c.bpos:c.bpos+uint(i)+1]...)
 				c.count = add


### PR DESCRIPTION
I've found another small performance optimization (up to 5%) for the chunker.

The chunker already skips nearly the complete minimum chunk size and
only processes the last 64 bytes to synchronize the shifting window.
The check whether a chunk already has the minimum chunk size always
happened before checking whether the chunk has found a split point.
The minimum size check is, however, only relevant for the first 64 bytes
used to synchronize the shifting window and never applies later on.

This change flips the order in which both checks are applied. That is
the minimum chunk size is only checked when a split point candidate was
found. As the latter happens rarely this removes one comparison and jump
from the inner loop.

Performance (30 seconds benchtime, 5 repetitions, formatted using
benchstat, benchmark is single threaded):
Old CPU: Intel(R) Xeon(R) CPU E5506 @ 2.13GHz
Chunker-4  269MB/s ± 4%  283MB/s ± 2%  +4.97%  (p=0.008 n=5+5)

Modern CPU: Intel(R) Xeon(R) CPU E3-1275 v5 @ 3.60GHz
Chunker-8  563MB/s ± 0%  563MB/s ± 0%   ~     (p=0.111 n=5+4)