### PR TITLE
Un-inline updateDigest

### DIFF
--- a/chunker.go
+++ b/chunker.go
@@ -222,8 +222,7 @@ func (c *Chunker) Next(data []byte) (Chunk, error) {
 		return Chunk{}, errors.New("tables for polynomial computation not initialized")
 	}
 
-	tabout := c.tables.out
-	tabmod := c.tables.mod
+	tab := &c.tables
 	polShift := c.polShift
 	// go guarantees the expected behavior for bit shifts even for shift counts
 	// larger than the value width. Bounding the value of polShift allows the compiler
@@ -301,15 +300,10 @@ func (c *Chunker) Next(data []byte) (Chunk, error) {
 			wpos = wpos % windowSize
 			out := win[wpos]
 			win[wpos] = b
-			digest ^= uint64(tabout[out])
+			digest ^= uint64(tab.out[out])
 			wpos++
 
-			// updateDigest
-			index := byte(digest >> polShift)
-			digest <<= 8
-			digest |= uint64(b)
-
-			digest ^= uint64(tabmod[index])
+			digest = updateDigest(digest, polShift, tab, b)
 			// end manual inline
 
 			add++


### PR DESCRIPTION
Go 1.14 can inline it without assistance. The benchmarks show a tiny, but significant speedup:

```
name                 old time/op   new time/op   delta
ChunkerWithSHA256-8    201ms ± 0%    201ms ± 0%    ~     (p=0.169 n=19+18)
Chunker-8             55.3ms ± 1%   55.0ms ± 0%  -0.40%  (p=0.000 n=18+16)
NewChunker-8          95.3µs ± 2%   95.7µs ± 3%    ~     (p=0.426 n=18+20)

name                 old speed     new speed     delta
ChunkerWithSHA256-8  167MB/s ± 0%  167MB/s ± 0%    ~     (p=0.152 n=19+18)
Chunker-8            607MB/s ± 1%  610MB/s ± 0%  +0.40%  (p=0.000 n=18+16)
```

This is most likely because the c.tables is no longer copied to the stack.