### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,8 @@ matrix:
       go: "1.9.x"
       arch: amd64
     - os: linux
-      go: "1.9.x"
-      arch: ppc64le
-    - os: linux
       go: "1.10.x"
       arch: amd64
-    - os: linux
-      go: "1.10.x"
-      arch: ppc64le
     - os: linux
       go: "tip"
       arch: amd64
@@ -24,9 +18,7 @@ matrix:
     - os: osx
       go: "1.10.x"
       arch: amd64
-    - os: osx
-      go: "1.10.x"
-      arch: ppc64le
+    
 
 install:
   - go get -t ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 sudo: false
-
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,28 @@ matrix:
   include:
     - os: linux
       go: "1.9.x"
+      arch: amd64
+    - os: linux
+      go: "1.9.x"
+      arch: ppc64le
     - os: linux
       go: "1.10.x"
+      arch: amd64
+    - os: linux
+      go: "1.10.x"
+      arch: ppc64le
     - os: linux
       go: "tip"
+      arch: amd64
+    - os: linux
+      go: "tip"
+      arch: ppc64le
     - os: osx
       go: "1.10.x"
+      arch: amd64
+    - os: osx
+      go: "1.10.x"
+      arch: ppc64le
 
 install:
   - go get -t ./...


### PR DESCRIPTION
Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/chunker

Please let me know if you need any further details.,

Thank You !!