### PR TITLE
Skip splitmask calculations until we reach minSize

### DIFF
--- a/chunker.go
+++ b/chunker.go
@@ -308,11 +308,11 @@ func (c *Chunker) Next(data []byte) (Chunk, error) {
 
 			add++
 
-			if (digest&c.splitmask) == 0 || add >= maxSize {
-				if add < minSize {
-					continue
-				}
+			if add < minSize {
+				continue
+			}
 
+			if (digest&c.splitmask) == 0 || add >= maxSize {
 				i := add - c.count - 1
 				data = append(data, c.buf[c.bpos:c.bpos+uint(i)+1]...)
 				c.count = add


### PR DESCRIPTION
In my tests it gives ~1% perf improvement, though margins are quite narrow and likely newer versions of the compiler would be able optimize this out automagically.

```
$ benchstat old new                                       
name       old time/op   new time/op   delta
Chunker-8   58.2ms ± 3%   57.4ms ± 4%  -1.45%  (p=0.012 n=18+19)

name       old speed     new speed     delta
Chunker-8  576MB/s ± 3%  585MB/s ± 4%  +1.68%  (p=0.004 n=17+19)
```