### PR TITLE
Separate buffer management and split point calculation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  latest_go: "1.18.x"
+  latest_go: "1.19.x"
   GO111MODULE: on
 
 jobs:
@@ -19,13 +19,18 @@ jobs:
         # list of jobs to run:
         include:
           - job_name: Windows
-            go: 1.18.x
+            go: 1.19.x
             os: windows-latest
             install_verb: install
 
           - job_name: macOS
-            go: 1.18.x
+            go: 1.19.x
             os: macOS-latest
+            install_verb: install
+
+          - job_name: Linux
+            go: 1.19.x
+            os: ubuntu-latest
             install_verb: install
 
           - job_name: Linux
@@ -83,7 +88,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45
+          version: v1.48
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true
           args: --verbose --timeout 5m

--- a/chunker_test.go
+++ b/chunker_test.go
@@ -114,11 +114,6 @@ func testWithData(t *testing.T, chnker *Chunker, testChunks []chunk, checkDigest
 			t.Fatalf("Error returned with chunk %d: %v", i, err)
 		}
 
-		if c.Start != pos {
-			t.Fatalf("Start for chunk %d does not match: expected %d, got %d",
-				i, pos, c.Start)
-		}
-
 		if c.Length != chunk.Length {
 			t.Fatalf("Length for chunk %d does not match: expected %d, got %d",
 				i, chunk.Length, c.Length)
@@ -252,6 +247,7 @@ func TestChunkerWithoutHash(t *testing.T) {
 	ch := New(bytes.NewReader(buf), testPol)
 	chunks := testWithData(t, ch, chunks1, false)
 
+	start := uint(0)
 	// test reader
 	for i, c := range chunks {
 		if uint(len(c.Data)) != chunks1[i].Length {
@@ -259,10 +255,11 @@ func TestChunkerWithoutHash(t *testing.T) {
 				chunks1[i].Length, len(c.Data))
 		}
 
-		if !bytes.Equal(buf[c.Start:c.Start+c.Length], c.Data) {
+		if !bytes.Equal(buf[start:start+c.Length], c.Data) {
 			t.Fatalf("invalid data for chunk returned: expected %02x, got %02x",
-				buf[c.Start:c.Start+c.Length], c.Data)
+				buf[start:start+c.Length], c.Data)
 		}
+		start += c.Length
 	}
 
 	// setup nullbyte data source

--- a/chunker_test.go
+++ b/chunker_test.go
@@ -114,6 +114,11 @@ func testWithData(t *testing.T, chnker *Chunker, testChunks []chunk, checkDigest
 			t.Fatalf("Error returned with chunk %d: %v", i, err)
 		}
 
+		if c.Start != pos {
+			t.Fatalf("Start for chunk %d does not match: expected %d, got %d",
+				i, pos, c.Start)
+		}
+
 		if c.Length != chunk.Length {
 			t.Fatalf("Length for chunk %d does not match: expected %d, got %d",
 				i, chunk.Length, c.Length)
@@ -247,7 +252,6 @@ func TestChunkerWithoutHash(t *testing.T) {
 	ch := New(bytes.NewReader(buf), testPol)
 	chunks := testWithData(t, ch, chunks1, false)
 
-	start := uint(0)
 	// test reader
 	for i, c := range chunks {
 		if uint(len(c.Data)) != chunks1[i].Length {
@@ -255,11 +259,10 @@ func TestChunkerWithoutHash(t *testing.T) {
 				chunks1[i].Length, len(c.Data))
 		}
 
-		if !bytes.Equal(buf[start:start+c.Length], c.Data) {
+		if !bytes.Equal(buf[c.Start:c.Start+c.Length], c.Data) {
 			t.Fatalf("invalid data for chunk returned: expected %02x, got %02x",
-				buf[start:start+c.Length], c.Data)
+				buf[c.Start:c.Start+c.Length], c.Data)
 		}
-		start += c.Length
 	}
 
 	// setup nullbyte data source


### PR DESCRIPTION
`Chunker.Next` currently handles buffer management and the split point calculation at the same time. While experimenting with a way to also chunk Tree blobs, I noticed that this combination is a problem: trees are built incrementally such that the Chunker cannot simply read the next part of the tree into its buffer. Moving the buffer out of the Chunker helps in this case, as it allows to manage a buffer in a way that better matches what is necessary to split tree blobs.

For now the PR splits the chunker into `BaseChunker` and `Chunker`. However, if the tree blob chunking works out as planned, then the `Chunker` will no longer be used by restic and could be removed unless there are other users.

Performance seems to be mostly unaffected, maybe even improve a tiny bit:
```
name               old time/op   new time/op   delta
ChunkerWithSHA256   93.3ms ± 0%   93.2ms ± 0%    ~     (p=1.000 n=9+9)
Chunker             41.7ms ± 0%   41.5ms ± 1%  -0.41%  (p=0.002 n=9+9)

name               old speed     new speed     delta
ChunkerWithSHA256  360MB/s ± 0%  360MB/s ± 0%    ~     (p=0.950 n=9+9)
Chunker            805MB/s ± 0%  808MB/s ± 1%  +0.41%  (p=0.002 n=9+9)
```