### PR TITLE
improve chunk throughput with elide array bound checks

### DIFF
--- a/chunker.go
+++ b/chunker.go
@@ -92,12 +92,10 @@ func (c *BaseChunker) reset() {
 		c.window[i] = 0
 	}
 
+	c.digest = 0
+	c.wpos = 0
 	c.count = 0
-
-	// slide in a byte
-	c.window[0] = 1
-	c.digest = updateDigest(uint64(c.tables.out[0]), c.polShift, &c.tables, 1)
-	c.wpos = 1
+	c.digest = c.slide(c.digest, 1)
 
 	// do not start a new chunk unless at least MinSize bytes have been read
 	c.pre = c.MinSize - windowSize
@@ -196,6 +194,7 @@ func (c *BaseChunker) NextSplitPoint(buf []byte) (int, uint64) {
 	win := c.window
 	wpos := c.wpos
 	for i, b := range buf {
+		// limit wpos to elide array bound checks
 		out := win[wpos%windowSize]
 		win[wpos%windowSize] = b
 		digest ^= uint64(tab.out[out])
@@ -227,6 +226,16 @@ func updateDigest(digest uint64, polShift uint, tab *tables, b byte) (newDigest 
 	digest |= uint64(b)
 
 	digest ^= uint64(tab.mod[index])
+	return digest
+}
+
+func (c *BaseChunker) slide(digest uint64, b byte) (newDigest uint64) {
+	out := c.window[c.wpos]
+	c.window[c.wpos] = b
+	digest ^= uint64(c.tables.out[out])
+	c.wpos = (c.wpos + 1) % windowSize
+
+	digest = updateDigest(digest, c.polShift, &c.tables, b)
 	return digest
 }
 


### PR DESCRIPTION
Gain about ~3% speedup by inlining the slide method and reducing one assignment statement.

```plain
goos: linux
goarch: amd64
pkg: github.com/restic/chunker
cpu: Intel(R) Xeon(R) Platinum 8269CY CPU @ 2.50GHz
                    │   old.txt    │               new.txt               │
                    │    sec/op    │    sec/op     vs base               │
ChunkerWithSHA256-8    158.7m ± 0%    154.3m ± 0%  -2.79% (p=0.000 n=10)
Chunker-8              65.72m ± 1%    61.49m ± 0%  -6.44% (p=0.000 n=10)
NewChunker-8           136.4µ ± 9%    131.3µ ± 4%       ~ (p=0.063 n=10)
PolDivMod-8            2.877n ± 0%    2.876n ± 0%       ~ (p=0.490 n=10)
PolDiv-8               2.890n ± 0%    2.891n ± 0%       ~ (p=0.952 n=10)
PolMod-8               2.894n ± 1%    2.894n ± 0%       ~ (p=0.809 n=10)
PolDeg-8              0.3148n ± 0%   0.3144n ± 0%       ~ (p=0.075 n=10)
RandomPolynomial-8     2.017m ± 3%    2.054m ± 4%       ~ (p=0.684 n=10)
PolIrreducible-8       1.146m ± 0%    1.146m ± 0%       ~ (p=0.971 n=10)
geomean                6.634µ         6.550µ       -1.28%

                    │   old.txt    │               new.txt               │
                    │     B/s      │     B/s       vs base               │
ChunkerWithSHA256-8   201.7Mi ± 0%   207.4Mi ± 0%  +2.87% (p=0.000 n=10)
Chunker-8             486.9Mi ± 1%   520.4Mi ± 0%  +6.88% (p=0.000 n=10)
geomean               313.4Mi        328.6Mi       +4.86%
```